### PR TITLE
dependencies were set to catkin_msgs instead of chatter_msgs

### DIFF
--- a/chatter_receiver/package.xml
+++ b/chatter_receiver/package.xml
@@ -10,9 +10,9 @@
   <author email="Felix.Sedlmeier@bmw-carit.de">Felix Sedlmeier</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>catkin_msgs</build_depend>
+  <build_depend>chatter_msgs</build_depend>
   <build_depend>roscpp</build_depend>
-  <run_depend>catkin_msgs</run_depend>
+  <run_depend>chatter_msgs</run_depend>
   <run_depend>roscpp</run_depend>
 
   <export>

--- a/chatter_sender/package.xml
+++ b/chatter_sender/package.xml
@@ -10,9 +10,9 @@
   <author email="Felix.Sedlmeier@bmw-carit.de">Felix Sedlmeier</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
-  <build_depend>catkin_msgs</build_depend>
+  <build_depend>chatter_msgs</build_depend>
   <build_depend>roscpp</build_depend>
-  <run_depend>catkin_msgs</run_depend>
+  <run_depend>chatter_msgs</run_depend>
   <run_depend>roscpp</run_depend>
 
   <export></export>


### PR DESCRIPTION
This is pretty straight forward, I guess it was an auto corrector or something like this.

Should I crease version?